### PR TITLE
Containerize e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Run E2E tests in Docker container
         run: |
           docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
-          docker cp playwright-e2e-container:/app/e2e/playwright-report ./playwright-report
+          docker cp playwright-e2e:/app/e2e/playwright-report ./e2e/playwright-report
 
       # Upload Playwright report as an artifact
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: ./playwright-report
+          path: ./e2e/playwright-report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,24 +15,17 @@ jobs:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     runs-on: ubuntu-latest
 
-    container:
-      image: mcr.microsoft.com/playwright:v1.48.1-noble
-
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
+      # Build the Docker image using the Dockerfile in the ./e2e/ folder
+      - name: Build Docker image
+        run: docker build -t playwright-e2e ./e2e
 
-      - name: Install Playwright browsers
-        run: make e2e-setup-ci
-
-      - name: Run e2e tests
-        run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+      # Run the Playwright tests inside the Docker container
+      - name: Run E2E tests in Docker container
+        run: docker run --rm playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Since the Docker image includes dependencies, no need to set up Node.js or Playwright browsers
       - name: Install make
         run: apt-get update && apt-get install -y make
 
+      # Install project dependencies
+      - name: Install npm dependencies
+        run: npm ci
 
       - name: Run e2e tests
         run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,10 @@ jobs:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     runs-on: ubuntu-latest
 
+    container:
+      image: mcr.microsoft.com/playwright:v1.48.1-noble
+
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
       - name: Build Docker image
-        run: docker build -t playwright-e2e ./e2e
+        run: docker build -t playwright-e2e .
 
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Run E2E tests in Docker container
         run: make e2e-run APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
-      # Copy the Playwright report from the container, so we can upload in later step
-      - name: Copy Playwright report
-        run: make e2e-copy-report
-
       # Remove the Docker container manually
       - name: Remove Docker container
         run: docker rm playwright-e2e-container

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,19 +15,17 @@ jobs:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     runs-on: ubuntu-latest
 
-    container:
-      image: mcr.microsoft.com/playwright:v1.48.1-noble
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install make
-        run: apt-get update && apt-get install -y make
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-      # Install project dependencies
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install Playwright browsers
+        run: make e2e-setup-ci
 
       - name: Run e2e tests
         run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container
-        run: make e2e-run APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+        run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,7 +26,9 @@ jobs:
       # Run the Playwright tests inside the Docker container
       # Ensure APP_NAME and BASE_URL are passed in correctly
       - name: Run E2E tests in Docker container
-        run: docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+        run: |
+          docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+          docker cp playwright-e2e-container:/app/e2e/playwright-report ./playwright-report
 
       # Upload Playwright report as an artifact
       - name: Upload Playwright report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Copy the Playwright report from the container, so we can upload in later step
       - name: Copy Playwright report
-        run: docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
+        run: make e2e-copy-report
 
       # Remove the Docker container manually
       - name: Remove Docker container

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,8 +25,7 @@ jobs:
 
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container
-        run: |
-          docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+        run: make e2e-run APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
       # Copy the Playwright report from the container, so we can upload in later step
       - name: Copy Playwright report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Run E2E tests in Docker container
         run: make e2e-run APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
-      # Remove the Docker container manually
-      - name: Remove Docker container
-        run: docker rm playwright-e2e-container
-
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,14 +21,14 @@ jobs:
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
       - name: Build Docker image
-        run: docker build -t playwright-e2e -f ./e2e/Dockerfile .
+        run: make e2e-build
 
-      # Run the Playwright tests inside the Docker container (without --rm flag)
+      # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container
         run: |
           docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
-      # Copy the Playwright report from the container
+      # Copy the Playwright report from the container, so we can upload in later step
       - name: Copy Playwright report
         run: docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
 
@@ -36,7 +36,6 @@ jobs:
       - name: Remove Docker container
         run: docker rm playwright-e2e-container
 
-      # Upload Playwright report as an artifact
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,12 +23,18 @@ jobs:
       - name: Build Docker image
         run: docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
-      # Run the Playwright tests inside the Docker container
-      # Ensure APP_NAME and BASE_URL are passed in correctly
+      # Run the Playwright tests inside the Docker container (without --rm flag)
       - name: Run E2E tests in Docker container
         run: |
-          docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
-          docker cp playwright-e2e:/app/e2e/playwright-report ./e2e/playwright-report
+          docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+
+      # Copy the Playwright report from the container
+      - name: Copy Playwright report
+        run: docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
+
+      # Remove the Docker container manually
+      - name: Remove Docker container
+        run: docker rm playwright-e2e-container
 
       # Upload Playwright report as an artifact
       - name: Upload Playwright report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       # Since the Docker image includes dependencies, no need to set up Node.js or Playwright browsers
+      - name: Install make
+        run: apt-get update && apt-get install -y make
+
 
       - name: Run e2e tests
         run: make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,14 +21,16 @@ jobs:
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
       - name: Build Docker image
-        run: docker build -t playwright-e2e ./e2e
+        run: docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
       # Run the Playwright tests inside the Docker container
+      # Ensure APP_NAME and BASE_URL are passed in correctly
       - name: Run E2E tests in Docker container
         run: docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
+      # Upload Playwright report as an artifact
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: ./e2e/playwright-report
+          path: /app/e2e/playwright-report  

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,10 +20,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Build the Docker image using the Dockerfile in the ./e2e/ folder
-      - name: Build Docker pimage
-        run: make e2e-build
-
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container
         run: make e2e-run APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,4 +33,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: /app/e2e/playwright-report  
+          path: ./playwright-report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,11 +21,11 @@ jobs:
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
       - name: Build Docker image
-        run: docker build -t playwright-e2e ./e2e  # <-- Point to the ./e2e directory
+        run: docker build -t playwright-e2e ./e2e
 
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container
-        run: docker run --rm playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
+        run: docker run --rm -w /app playwright-e2e make e2e-test APP_NAME=${{ inputs.app_name }} BASE_URL=${{ inputs.service_endpoint }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
       - name: Build Docker image
-        run: docker build -t playwright-e2e .
+        run: docker build -t playwright-e2e ./e2e  # <-- Point to the ./e2e directory
 
       # Run the Playwright tests inside the Docker container
       - name: Run E2E tests in Docker container

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,5 @@
 name: E2E Tests
+run-name: E2E Tests
 
 on:
   workflow_call:
@@ -12,7 +13,7 @@ on:
 
 jobs:
   e2e:
-    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    name: "E2E Tests"
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Build the Docker image using the Dockerfile in the ./e2e/ folder
-      - name: Build Docker image
+      - name: Build Docker pimage
         run: make e2e-build
 
       # Run the Playwright tests inside the Docker container

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -65,7 +65,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   e2e-tests:
-    name: " "
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
     needs: [update]
     uses: ./.github/workflows/e2e-tests.yml
     with:

--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -65,7 +65,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   e2e-tests:
-    name: Run E2E Tests
+    name: " "
     needs: [update]
     uses: ./.github/workflows/e2e-tests.yml
     with:

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ e2e-copy-report: ## Copy the Playwright report from the container to local
 e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
 	rm -rf ./e2e/playwright-report
 
-e2e-delete-image: ## Delete the Docker image for e2e tests entirely
+e2e-delete-image: ## Delete the Docker image for e2e tests
 	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
 
 e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,6 @@ e2e-setup-ci: ## Install system dependencies, Node dependencies, and Playwright 
 	libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libharfbuzz-icu0 libhyphen0 \
 	libenchant-2-2 libflite1 libgles2 libx264-dev
 	cd e2e && npm ci
-	cd e2e && npx playwright install --with-deps
 
 
 e2e-test: ## Run end-to-end tests

--- a/Makefile
+++ b/Makefile
@@ -235,10 +235,10 @@ e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
 e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
+	docker rm -f playwright-e2e-container || true
 	docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL)
 	$(MAKE) e2e-clean-report
 	$(MAKE) e2e-copy-report
-	docker rm playwright-e2e-container
 
 e2e-copy-report: ## Copy the Playwright report from the container to local
 	docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,10 @@ e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps
 
+e2e-setup-ci: ## Setup end-to-end tests for CI
+	@cd e2e && npm ci
+	@cd e2e && npx playwright install --with-deps
+
 e2e-show-report: ## Show the ./e2e/playwright-report
 	@cd e2e && npx playwright show-report
 

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ release-image-tag: ## Prints the image tag of the release image
 ## End-to-end (E2E) Testing ##
 ##############################
 
-e2e-check-build: ## Build the e2e Docker image, if not already built, using ./e2e/Dockerfile
+e2e-build: ## Build the e2e Docker image, if not already built, using ./e2e/Dockerfile
 	@if [ -z "$$(docker images -q playwright-e2e)" ]; then \
 	  echo "Building Docker image..."; \
 	  docker build -t playwright-e2e -f ./e2e/Dockerfile .; \

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
 	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
 e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally
+e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker rm -f playwright-e2e-container || true
@@ -245,6 +246,9 @@ e2e-copy-report: ## Copy the Playwright report from the container to local
 
 e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
 	rm -rf ./e2e/playwright-report
+
+e2e-show-report: ## Show the ./e2e/playwright-report
+	@cd e2e && npx playwright show-report
 
 e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ __check_defined = \
 
 
 .PHONY : \
+	e2e-build \
+	e2e-copy-report \
+	e2e-run \
+	e2e-setup-native \
+	e2e-test \
 	help \
 	infra-check-app-database-roles \
 	infra-check-compliance-checkov \
@@ -59,12 +64,7 @@ __check_defined = \
 	release-image-name \
 	release-image-tag \
 	release-publish \
-	release-run-database-migrations \
-	e2e-build \
-	e2e-run \
-	e2e-copy-report \
-	e2e-setup-native \
-	e2e-test
+	release-run-database-migrations
 
 infra-set-up-account: ## Configure and create resources for current AWS profile and save tfbackend file to infra/accounts/$ACCOUNT_NAME.ACCOUNT_ID.s3.tfbackend
 	@:$(call check_defined, ACCOUNT_NAME, human readable name for account e.g. "prod" or the AWS account alias)

--- a/Makefile
+++ b/Makefile
@@ -248,10 +248,13 @@ e2e-run: ## Run the Playwright tests in a Docker container and copy the report l
 e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
-	docker rm -f playwright-e2e-container || true
-	docker run --name playwright-e2e-container -e APP_NAME=$(APP_NAME) -e BASE_URL=$(BASE_URL) playwright-e2e
-	$(MAKE) e2e-clean-report
-	$(MAKE) e2e-copy-report
+	mkdir -p ./e2e/playwright-report  # Ensure the local report directory exists
+	docker run --rm \
+		--name playwright-e2e-container \
+		-e APP_NAME=$(APP_NAME) \
+		-e BASE_URL=$(BASE_URL) \
+		-v $(PWD)/e2e/playwright-report:/e2e/playwright-report \
+		playwright-e2e
 
 e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ e2e-run: ## Run the Playwright tests in Docker container
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL)
 
+e2e-copy-report: ## Copy the Playwright report from the container
+	docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
+
 e2e-setup: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps

--- a/Makefile
+++ b/Makefile
@@ -232,13 +232,19 @@ release-image-tag: ## Prints the image tag of the release image
 e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
 	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
-e2e-run: ## Run the Playwright tests in a Docker container
+e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL)
+	$(MAKE) e2e-clean-report
+	$(MAKE) e2e-copy-report
+	docker rm playwright-e2e-container
 
 e2e-copy-report: ## Copy the Playwright report from the container to local
 	docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
+
+e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
+	rm -rf ./e2e/playwright-report
 
 e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install

--- a/Makefile
+++ b/Makefile
@@ -246,8 +246,11 @@ e2e-run: e2e-build
 	$(MAKE) e2e-clean-report
 	$(MAKE) e2e-copy-report
 
+e2e-delete-image: ## Delete the Docker image for e2e tests entirely
+	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
+
 e2e-copy-report: ## Copy the Playwright report from the container to local
-	docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
+	docker cp playwright-e2e-container:/e2e/playwright-report ./e2e/playwright-report
 
 e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
 	rm -rf ./e2e/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker rm -f playwright-e2e-container || true
-	docker run --name playwright-e2e-container -w /app -e APP_NAME=$(APP_NAME) -e BASE_URL=$(BASE_URL) playwright-e2e
+	docker run --name playwright-e2e-container -e APP_NAME=$(APP_NAME) -e BASE_URL=$(BASE_URL) playwright-e2e
 	$(MAKE) e2e-clean-report
 	$(MAKE) e2e-copy-report
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ __check_defined = \
 
 .PHONY : \
 	e2e-build \
+	e2e-clean-report \
 	e2e-copy-report \
+	e2e-delete-image \
 	e2e-run \
 	e2e-setup-native \
+	e2e-show-report \
 	e2e-test \
 	help \
 	infra-check-app-database-roles \

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,6 @@ e2e-run: ## Run the Playwright tests in a Docker container and copy the report l
 e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
-	mkdir -p ./e2e/playwright-report
 	docker run --rm \
 		--name playwright-e2e-container \
 		-e APP_NAME=$(APP_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,15 @@ e2e-build: ## Build the e2e Docker image, if not already built, using ./e2e/Dock
 	  echo "Docker image already exists, skipping build."; \
 	fi
 
+e2e-copy-report: ## Copy the Playwright report from the container to local
+	docker cp playwright-e2e-container:/e2e/playwright-report ./e2e/playwright-report
+
+e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
+	rm -rf ./e2e/playwright-report
+
+e2e-delete-image: ## Delete the Docker image for e2e tests entirely
+	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
+
 e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally
 e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
@@ -246,21 +255,13 @@ e2e-run: e2e-build
 	$(MAKE) e2e-clean-report
 	$(MAKE) e2e-copy-report
 
-e2e-delete-image: ## Delete the Docker image for e2e tests entirely
-	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
-
-e2e-copy-report: ## Copy the Playwright report from the container to local
-	docker cp playwright-e2e-container:/e2e/playwright-report ./e2e/playwright-report
-
-e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
-	rm -rf ./e2e/playwright-report
+e2e-setup-native: ## Setup end-to-end tests
+	@cd e2e && npm install
+	@cd
+	e2e && npx playwright install --with-deps
 
 e2e-show-report: ## Show the ./e2e/playwright-report
 	@cd e2e && npx playwright show-report
-
-e2e-setup-native: ## Setup end-to-end tests
-	@cd e2e && npm install
-	@cd e2e && npx playwright install --with-deps
 
 e2e-test: ## Run end-to-end tests
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,11 @@ release-image-tag: ## Prints the image tag of the release image
 e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
 	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
+e2e-run: ## Run the Playwright tests in Docker container
+	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
+	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
+	docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL)
+
 e2e-setup: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ __check_defined = \
 .PHONY : \
 	e2e-build \
 	e2e-clean-report \
-	e2e-copy-report \
 	e2e-delete-image \
-	e2e-run \
+	e2e-setup-ci \
 	e2e-setup-native \
 	e2e-show-report \
 	e2e-test \
+	e2e-test-native
 	help \
 	infra-check-app-database-roles \
 	infra-check-compliance-checkov \
@@ -235,17 +235,14 @@ release-image-tag: ## Prints the image tag of the release image
 e2e-build: ## Build the e2e Docker image, if not already built, using ./e2e/Dockerfile
 	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
-e2e-copy-report: ## Copy the Playwright report from the container to local
-	docker cp playwright-e2e-container:/e2e/playwright-report ./e2e/playwright-report
-
 e2e-clean-report: ## Remove the local ./e2e/playwright-report folder and its contents
 	rm -rf ./e2e/playwright-report
 
 e2e-delete-image: ## Delete the Docker image for e2e tests
 	@docker rmi -f playwright-e2e 2>/dev/null || echo "Docker image playwright-e2e does not exist, skipping."
 
-e2e-run: ## Run the Playwright tests in a Docker container and copy the report locally
-e2e-run: e2e-build
+e2e-test: ## Run E2E Playwright tests in a Docker container and copy the report locally
+e2e-test: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker run --rm \
@@ -266,7 +263,7 @@ e2e-setup-ci: ## Setup end-to-end tests for CI
 e2e-show-report: ## Show the ./e2e/playwright-report
 	@cd e2e && npx playwright show-report
 
-e2e-test: ## Run end-to-end tests
+e2e-test-native: ## Run end-to-end tests
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	@cd e2e/$(APP_NAME) && APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL) npx playwright test $(E2E_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -257,8 +257,7 @@ e2e-run: e2e-build
 
 e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install
-	@cd
-	e2e && npx playwright install --with-deps
+	@cd	e2e && npx playwright install --with-deps
 
 e2e-show-report: ## Show the ./e2e/playwright-report
 	@cd e2e && npx playwright show-report

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ __check_defined = \
 	release-image-tag \
 	release-publish \
 	release-run-database-migrations \
-	e2e-setup \
+	e2e-build \
+	e2e-run \
+	e2e-copy-report \
+	e2e-setup-native \
 	e2e-test
 
 infra-set-up-account: ## Configure and create resources for current AWS profile and save tfbackend file to infra/accounts/$ACCOUNT_NAME.ACCOUNT_ID.s3.tfbackend

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ e2e-run: e2e-build
 
 e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install
-	@cd	e2e && npx playwright install --with-deps
+	@cd e2e && npx playwright install --with-deps
 
 e2e-show-report: ## Show the ./e2e/playwright-report
 	@cd e2e && npx playwright show-report

--- a/Makefile
+++ b/Makefile
@@ -229,15 +229,15 @@ release-image-tag: ## Prints the image tag of the release image
 e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
 	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
-e2e-run: ## Run the Playwright tests in Docker container
+e2e-run: ## Run the Playwright tests in a Docker container
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
 	docker run --name playwright-e2e-container -w /app playwright-e2e make e2e-test APP_NAME=$(APP_NAME) BASE_URL=$(BASE_URL)
 
-e2e-copy-report: ## Copy the Playwright report from the container
+e2e-copy-report: ## Copy the Playwright report from the container to local
 	docker cp playwright-e2e-container:/app/e2e/playwright-report ./e2e/playwright-report
 
-e2e-setup: ## Setup end-to-end tests
+e2e-setup-native: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps
 

--- a/Makefile
+++ b/Makefile
@@ -241,14 +241,6 @@ e2e-setup: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps
 
-e2e-setup-ci: ## Install system dependencies, Node dependencies, and Playwright browsers
-	sudo apt-get update
-	sudo apt-get install -y libwoff1 libopus0 libvpx7 libevent-2.1-7 libopus0 libgstreamer1.0-0 \
-	libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libharfbuzz-icu0 libhyphen0 \
-	libenchant-2-2 libflite1 libgles2 libx264-dev
-	cd e2e && npm ci
-
-
 e2e-test: ## Run end-to-end tests
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)

--- a/Makefile
+++ b/Makefile
@@ -233,12 +233,7 @@ release-image-tag: ## Prints the image tag of the release image
 ##############################
 
 e2e-build: ## Build the e2e Docker image, if not already built, using ./e2e/Dockerfile
-	@if [ -z "$$(docker images -q playwright-e2e)" ]; then \
-	  echo "Building Docker image..."; \
-	  docker build -t playwright-e2e -f ./e2e/Dockerfile .; \
-	else \
-	  echo "Docker image already exists, skipping build."; \
-	fi
+	docker build -t playwright-e2e -f ./e2e/Dockerfile .
 
 e2e-copy-report: ## Copy the Playwright report from the container to local
 	docker cp playwright-e2e-container:/e2e/playwright-report ./e2e/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ e2e-run: ## Run the Playwright tests in a Docker container and copy the report l
 e2e-run: e2e-build
 	@:$(call check_defined, APP_NAME, You must pass in a specific APP_NAME)
 	@:$(call check_defined, BASE_URL, You must pass in a BASE_URL)
-	mkdir -p ./e2e/playwright-report  # Ensure the local report directory exists
+	mkdir -p ./e2e/playwright-report
 	docker run --rm \
 		--name playwright-e2e-container \
 		-e APP_NAME=$(APP_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,9 @@ release-image-tag: ## Prints the image tag of the release image
 ## End-to-end (E2E) Testing ##
 ##############################
 
+e2e-build: ## Build the Docker image using the Dockerfile in the ./e2e/ folder
+	docker build -t playwright-e2e -f ./e2e/Dockerfile .
+
 e2e-setup: ## Setup end-to-end tests
 	@cd e2e && npm install
 	@cd e2e && npx playwright install --with-deps

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -50,7 +50,7 @@ Some highlights:
       From root folder:<br>
       <ul style="list-style-position:inside; text-align:left;">
         <li><code>make e2e-setup-native</code></li>
-        <li><code>make e2e-test APP_NAME=app BASE_URL=http://localhost:3001</code></li>
+        <li><code>make e2e-test APP_NAME=app BASE_URL=http://localhost:3000</code></li>
         <li><code>make e2e-copy-report</code></li>
       </ul>
     </td>

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository uses [Playwright](https://playwright.dev/) to perform end-to-end (E2E) tests. The tests can be run locally, but also run on [Pull Request preview environments](../infra/pull-request-environments.md). This ensures that any new code changes are validated through E2E tests before being merged.
+This repository uses [Playwright](https://playwright.dev/) to perform end-to-end (E2E) tests. The tests can be run locally (natively or within Docker), but they also run on [Pull Request preview environments](../infra/pull-request-environments.md). This ensures that any new code changes are validated through E2E tests before being merged.
 
 ## Folder Structure
 In order to support e2e for multiple apps, the folder structure will include a base playwright config (`./e2e/playwright.config.js`), and app-specific derived playwright config that override the base config. See the example folder structure below:
@@ -45,7 +45,7 @@ Some highlights:
       From root folder:<br>
       <ul style="list-style-position:inside; text-align:left;">
         <li><code>make e2e-setup-native</code></li>
-        <li><code>make e2e-test</code></li>
+        <li><code>make e2e-test APP_NAME=app BASE_URL=http://localhost:3001</code></li>
         <li><code>make e2e-copy-report</code></li>
       </ul>
     </td>
@@ -78,12 +78,14 @@ Some highlights:
   </tr>
   <tr>
     <td style="vertical-align:top;">Show Report</td>
-    <td colspan="2" style="vertical-align:top;"><code>npx playwright show-report</code></td>
+    <td colspan="2" style="vertical-align:top;">From the <code>./e2e</code> folder: <br /><code>npx playwright show-report</code></td>
     <td style="vertical-align:top;">View Artifacts of Github Actions job</td>
   </tr>
 </table>
 
-* Running local with Docker is the recommended approach
+- Running local with Docker is the preferred approach
+    - When running locally with Docker, the `playwright-report` will be copied to your local `./e2e/` folder
+- For all local runs, your application needs to be running
 
 ### PR Environments
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -27,7 +27,7 @@ Some highlights:
 
 ## Run tests locally
 
-### Running tests with docker (preferred)
+### Run tests with docker (preferred)
 
 First, make sure the application you want to test is running.
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -60,8 +60,7 @@ Some highlights:
     </td>
     <td style="vertical-align:top;">
       <em>* uses make commands <br /><br /> see the relevant <a href="../../.github/workflows/e2e-tests.yml">e2e Github Actions workflow file</a>
-
-</em>
+    </em>
     </td>
   </tr>
   <tr>

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -56,12 +56,9 @@ make e2e-test APP_NAME=app BASE_URL=http://localhost:3000
 
 
 ### Viewing the Report
-To copy the report from the container to your local machine for viewing
-```bash
-make e2e-copy-report
-```
+If running in docker, the report will be copied from the container to your local `./e2e/playwright-report` folder. If running natively, the report will also appear in this same folder.
 
-Once the report is in your local `./e2e` folder,  you can run:
+To quickly view the report, you can run:
 
 ```bash
 make e2e-show-report
@@ -70,7 +67,7 @@ make e2e-show-report
 *On CI, the report shows up in the Github Actions artifacts tab
 
 
-### PR Environments
+### PR Preview Environments
 
 The E2E tests are triggered in PR preview environments on each PR update. For more information on how PR environments work, please refer to [PR Environments Documentation](../infra/pull-request-environments.md).
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -26,29 +26,63 @@ Some highlights:
 - Parallelism limited on CI to ensure stable execution
 - Accessibility testing can be performed using the `@axe-core/playwright` package (https://playwright.dev/docs/accessibility-testing)
 
+## How to Run Tests
+<table border="1" style="width:100%; text-align:center;">
+  <tr>
+    <th></th>
+    <th>Local Natively Without Docker</th>
+    <th>Local With Docker</th>
+    <th>CI / Github Actions</th>
+  </tr>
+  <tr>
+  <td>Location App is Running</td>
+  <td colspan="2" style="vertical-align:top;">Locally (*port 3000 in examples) </td>
+  <td>PR Preview Environment</td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top;">With make commands</td>
+    <td style="vertical-align:top;">
+      From root folder:<br>
+      <ul style="list-style-position:inside; text-align:left;">
+        <li><code>make e2e-setup-native</code></li>
+        <li><code>make e2e-test</code></li>
+        <li><code>make e2e-copy-report</code></li>
+      </ul>
+    </td>
+    <td style="vertical-align:top;">
+      From root folder:<br>
+      <ul style="list-style-position:inside; text-align:left;">
+        <li><code>make e2e-build</code></li>
+        <li><code>make e2e-run APP_NAME=app BASE_URL=http://host.docker.internal:3000</code></li>
+        <br />
+        <em>* BASE_URL cannot use localhost</em>
+      </ul>
+    </td>
+    <td style="vertical-align:top;">
+      <em>* uses make commands <br /><br /> see the relevant <a href="../../.github/workflows/e2e-tests.yml">e2e Github Actions workflow file</a>
 
-## Running Locally
-
-### Running Locally From the Root Directory
-
-Make targets are setup to easily pass in a particular app name and URL to run tests against
-
-```bash
-make e2e-setup # install playwright deps
-make e2e-test APP_NAME=app BASE_URL=http://localhost:3000 # run tests on a particular app
-```
-
-### Running Locally From the `./e2e` Directory
-
-If you prefer to run package.json run scripts, you can do so from the e2e folder:
-
-```
-cd e2e
-
-npm install
-
-APP_NAME=app npm run e2e-test
-```
+</em>
+    </td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top;">Without make commands</td>
+    <td style="vertical-align:top;">
+      From <code>./e2e</code> folder:<br>
+      <ul style="list-style-position:inside; text-align:left;">
+        <li><code>npm install</code></li>
+        <li><code>npm run e2e-setup</code></li>
+        <li><code>APP_NAME=app BASE_URL=http://localhost:3000 npm run e2e-test</code></li>
+      </ul>
+    </td>
+    <td style="vertical-align:top;">N/A</td>
+    <td style="vertical-align:top;">N/A</td>
+  </tr>
+  <tr>
+    <td style="vertical-align:top;">Show Report</td>
+    <td colspan="2" style="vertical-align:top;"><code>npx playwright show-report</code></td>
+    <td style="vertical-align:top;">View Artifacts of Github Actions job</td>
+  </tr>
+</table>
 
 ### PR Environments
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -25,21 +25,21 @@ Some highlights:
 - HTML reports are output to the `playwright-report` folder
 - Accessibility testing can be performed using the `@axe-core/playwright` package (https://playwright.dev/docs/accessibility-testing)
 
-## Running Tests Locally
+## Run tests locally
 
-### Running Tests with Docker (preferred)
+### Running tests with docker (preferred)
 
 First, make sure the application you want to test is running.
 
 Then, run end-to-end tests using Docker with:
 ```bash
-make e2e-run APP_NAME=app BASE_URL=http://host.docker.internal:3000
+make e2e-test APP_NAME=app BASE_URL=http://host.docker.internal:3000
 ```
 
 *Note that `BASE_URL` cannot be `localhost`
 
 
-### Running tests Natively
+### Run tests natively
 
 First, make sure the application you want to test is running.
 
@@ -51,11 +51,11 @@ make e2e-setup-native
 
 Then, run the tests with your app name and base url:
 ```bash
-make e2e-test APP_NAME=app BASE_URL=http://localhost:3000
+make e2e-test-native APP_NAME=app BASE_URL=http://localhost:3000
 ```
 
 
-### Viewing the Report
+### Viewing the report
 If running in docker, the report will be copied from the container to your local `./e2e/playwright-report` folder. If running natively, the report will also appear in this same folder.
 
 To quickly view the report, you can run:
@@ -73,7 +73,7 @@ make e2e-clean-report
 *On CI, the report shows up in the Github Actions artifacts tab
 
 
-### PR Preview Environments
+### PR preview environments
 
 The E2E tests are triggered in PR preview environments on each PR update. For more information on how PR environments work, please refer to [PR Environments Documentation](../infra/pull-request-environments.md).
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -26,6 +26,11 @@ Some highlights:
 - Parallelism limited on CI to ensure stable execution
 - Accessibility testing can be performed using the `@axe-core/playwright` package (https://playwright.dev/docs/accessibility-testing)
 
+### Running with Docker
+
+
+
+
 ## How to Run Tests
 <table border="1" style="width:100%; text-align:center;">
   <tr>
@@ -52,7 +57,6 @@ Some highlights:
     <td style="vertical-align:top;">
       From root folder:<br>
       <ul style="list-style-position:inside; text-align:left;">
-        <li><code>make e2e-build</code></li>
         <li><code>make e2e-run APP_NAME=app BASE_URL=http://host.docker.internal:3000</code></li>
         <br />
         <em>* BASE_URL cannot use localhost</em>
@@ -63,22 +67,10 @@ Some highlights:
     </em>
     </td>
   </tr>
-  <tr>
-    <td style="vertical-align:top;">Without make commands</td>
-    <td style="vertical-align:top;">
-      From <code>./e2e</code> folder:<br>
-      <ul style="list-style-position:inside; text-align:left;">
-        <li><code>npm install</code></li>
-        <li><code>npm run e2e-setup</code></li>
-        <li><code>APP_NAME=app BASE_URL=http://localhost:3000 npm run e2e-test</code></li>
-      </ul>
-    </td>
-    <td style="vertical-align:top;">N/A</td>
-    <td style="vertical-align:top;">N/A</td>
-  </tr>
+
   <tr>
     <td style="vertical-align:top;">Show Report</td>
-    <td colspan="2" style="vertical-align:top;">From the <code>./e2e</code> folder: <br /><code>npx playwright show-report</code></td>
+    <td colspan="2" style="vertical-align:top;">From the root: <br /><code>make e2e-show-report</code></td>
     <td style="vertical-align:top;">View Artifacts of Github Actions job</td>
   </tr>
 </table>
@@ -86,6 +78,7 @@ Some highlights:
 - Running local with Docker is the preferred approach
     - When running locally with Docker, the `playwright-report` will be copied to your local `./e2e/` folder
 - For all local runs, your application needs to be running
+
 
 ### PR Environments
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -21,63 +21,53 @@ In order to support e2e for multiple apps, the folder structure will include a b
 
 Some highlights:
 - By default, the base config is defined to run on a minimal browser-set (desktop and mobile chrome). Browsers can be added in the app-specific playwright config.
-- Snapshots will be output locally or in the artifacts of the CI job
+- Snapshots will be output locally (in the `./e2e` folder or the container) - or in the artifacts of the CI job
 - HTML reports are output to the `playwright-report` folder
-- Parallelism limited on CI to ensure stable execution
 - Accessibility testing can be performed using the `@axe-core/playwright` package (https://playwright.dev/docs/accessibility-testing)
 
-### Running with Docker
+## Running Tests Locally
+
+### Running Tests with Docker (preferred)
+
+First, make sure the application you want to test is running.
+
+Then, run end-to-end tests using Docker with:
+```bash
+make e2e-run APP_NAME=app BASE_URL=http://host.docker.internal:3000
+```
+
+*Note that `BASE_URL` cannot be `localhost`
 
 
+### Running tests Natively
+
+First, make sure the application you want to test is running.
+
+To run end-to-end tests natively, first install Playwright with:
+
+```bash
+make e2e-setup-native
+```
+
+Then, run the tests with your app name and base url:
+```bash
+make e2e-test APP_NAME=app BASE_URL=http://localhost:3000
+```
 
 
-## How to Run Tests
-<table border="1" style="width:100%; text-align:center;">
-  <tr>
-    <th></th>
-    <th>Local Natively Without Docker</th>
-    <th>Local With Docker</th>
-    <th>CI / Github Actions</th>
-  </tr>
-  <tr>
-  <td>Location App is Running</td>
-  <td colspan="2" style="vertical-align:top;">Locally (*port 3000 in examples) </td>
-  <td>PR Preview Environment</td>
-  </tr>
-  <tr>
-    <td style="vertical-align:top;">With make commands</td>
-    <td style="vertical-align:top;">
-      From root folder:<br>
-      <ul style="list-style-position:inside; text-align:left;">
-        <li><code>make e2e-setup-native</code></li>
-        <li><code>make e2e-test APP_NAME=app BASE_URL=http://localhost:3000</code></li>
-        <li><code>make e2e-copy-report</code></li>
-      </ul>
-    </td>
-    <td style="vertical-align:top;">
-      From root folder:<br>
-      <ul style="list-style-position:inside; text-align:left;">
-        <li><code>make e2e-run APP_NAME=app BASE_URL=http://host.docker.internal:3000</code></li>
-        <br />
-        <em>* BASE_URL cannot use localhost</em>
-      </ul>
-    </td>
-    <td style="vertical-align:top;">
-      <em>* uses make commands <br /><br /> see the relevant <a href="../../.github/workflows/e2e-tests.yml">e2e Github Actions workflow file</a>
-    </em>
-    </td>
-  </tr>
+### Viewing the Report
+To copy the report from the container to your local machine for viewing
+```bash
+make e2e-copy-report
+```
 
-  <tr>
-    <td style="vertical-align:top;">Show Report</td>
-    <td colspan="2" style="vertical-align:top;">From the root: <br /><code>make e2e-show-report</code></td>
-    <td style="vertical-align:top;">View Artifacts of Github Actions job</td>
-  </tr>
-</table>
+Once the report is in your local `./e2e` folder,  you can run:
 
-- Running local with Docker is the preferred approach
-    - When running locally with Docker, the `playwright-report` will be copied to your local `./e2e/` folder
-- For all local runs, your application needs to be running
+```bash
+make e2e-show-report
+```
+
+*On CI, the report shows up in the Github Actions artifacts tab
 
 
 ### PR Environments

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -64,6 +64,12 @@ To quickly view the report, you can run:
 make e2e-show-report
 ```
 
+To clean the report folder you can run:
+
+```bash
+make e2e-clean-report
+```
+
 *On CI, the report shows up in the Github Actions artifacts tab
 
 

--- a/docs/e2e/e2e-checks.md
+++ b/docs/e2e/e2e-checks.md
@@ -83,6 +83,8 @@ Some highlights:
   </tr>
 </table>
 
+* Running local with Docker is the recommended approach
+
 ### PR Environments
 
 The E2E tests are triggered in PR preview environments on each PR update. For more information on how PR environments work, please refer to [PR Environments Documentation](../infra/pull-request-environments.md).

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -11,12 +11,8 @@ WORKDIR /
 COPY Makefile /Makefile
 COPY e2e /e2e
 
-# Install the dependencies inside the /e2e directory
-WORKDIR /e2e
-RUN npm ci
-
-# Install Playwright browsers and other necessary system dependencies
-RUN npx playwright install --with-deps
+# Run the Makefile target to set up end-to-end tests for CI
+RUN make e2e-setup-ci
 
 # Change the working directory back to the root to run the Makefile
 WORKDIR /

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -4,16 +4,16 @@ FROM mcr.microsoft.com/playwright:v1.48.1-noble
 # Install make and any other necessary dependencies
 RUN apt-get update && apt-get install -y make
 
-# Set the working directory to the root of the project
+# Set the working directory to the root of the project inside the Docker container
 WORKDIR /app
 
-# Copy the entire project, including Makefile, into the Docker image
-COPY . .
+# Copy the required files and directories from the root of the project
+COPY ../Makefile /app/Makefile
+COPY ../app /app/app
+COPY ../e2e /app/e2e
 
-# Change directory to e2e for subsequent commands
+# Install the dependencies inside the /e2e directory
 WORKDIR /app/e2e
-
-# Install the dependencies
 RUN npm ci
 
 # Install Playwright browsers and other necessary system dependencies
@@ -22,5 +22,5 @@ RUN npx playwright install --with-deps
 # Change the working directory back to the root to run the Makefile
 WORKDIR /app
 
-# Define the default command to run the tests (you can override this in your CI or local runs)
-CMD ["make", "e2e-test"]
+# Define the default command to run the tests
+# CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Playwright image as a base
+FROM mcr.microsoft.com/playwright:v1.48.1-noble
+
+# Install make and any other necessary dependencies
+RUN apt-get update && apt-get install -y make
+
+# Set the working directory
+WORKDIR /app
+
+# Copy your package.json and lock files to install dependencies
+COPY package.json package-lock.json ./
+
+# Install only the dependencies from package.json (ensure lock file exists for npm ci)
+RUN npm ci
+
+# Copy the rest of your application code
+COPY . .
+
+# Define the command to run the tests (you can override this in your CI or local runs)
+CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -4,17 +4,17 @@ FROM mcr.microsoft.com/playwright:v1.48.1-noble
 # Install make and any other necessary dependencies
 RUN apt-get update && apt-get install -y make
 
-# Set the working directory
+# Set the working directory to the root of the project
 WORKDIR /app
 
-# Copy your package.json and lock files to install dependencies
-COPY package.json package-lock.json ./
-
-# Install only the dependencies from package.json (ensure lock file exists for npm ci)
-RUN npm ci
-
-# Copy the rest of your application code
+# Copy the entire project into the container
 COPY . .
 
-# Define the command to run the tests (you can override this in your CI or local runs)
+# Change directory to e2e for subsequent commands
+WORKDIR /app/e2e
+
+# Install the dependencies
+RUN npm ci
+
+# Define the default command to run the tests (you can override this in your CI or local runs)
 CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -7,14 +7,15 @@ RUN apt-get update && apt-get install -y make
 # Set the working directory to the root of the project inside the Docker container
 WORKDIR /
 
-# Copy the required files and directories from the root of the project into the Docker container
+# Setup npm install layer that can be cached
 COPY Makefile /Makefile
-COPY e2e /e2e
-
-# Run the Makefile target to set up end-to-end tests for CI
+COPY e2e/package.json e2e/package-lock.json /e2e/
 RUN make e2e-setup-ci
 
-# Change the working directory back to the root to run the Makefile
+# Copy entire e2e folder over
+COPY e2e /e2e
+
+# Change the working directory back to the root to run Makefile commands
 WORKDIR /
 
 # Default command when running the container

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -7,14 +7,17 @@ RUN apt-get update && apt-get install -y make
 # Set the working directory to the root of the project
 WORKDIR /app
 
-# Copy the entire project into the container
-COPY . .
+# Copy the entire project, including Makefile, into the Docker image
+COPY ../ .
 
 # Change directory to e2e for subsequent commands
 WORKDIR /app/e2e
 
 # Install the dependencies
 RUN npm ci
+
+# Install Playwright browsers and other necessary system dependencies
+RUN npx playwright install --with-deps
 
 # Change the working directory back to the root to run the Makefile
 WORKDIR /app

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -20,3 +20,6 @@ RUN npx playwright install --with-deps
 
 # Change the working directory back to the root to run the Makefile
 WORKDIR /app
+
+# Default command when running the container
+CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /app
 
 # Copy the required files and directories from the root of the project into the Docker container
 COPY Makefile /app/Makefile
-COPY app /app/app
 COPY e2e /app/e2e
 
 # Install the dependencies inside the /e2e directory
@@ -21,4 +20,3 @@ RUN npx playwright install --with-deps
 
 # Change the working directory back to the root to run the Makefile
 WORKDIR /app
-

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update && apt-get install -y make
 # Set the working directory to the root of the project inside the Docker container
 WORKDIR /app
 
-# Copy the required files and directories from the root of the project
-COPY ../Makefile /app/Makefile
-COPY ../app /app/app
-COPY ../e2e /app/e2e
+# Copy the required files and directories from the root of the project into the Docker container
+COPY Makefile /app/Makefile
+COPY app /app/app
+COPY e2e /app/e2e
 
 # Install the dependencies inside the /e2e directory
 WORKDIR /app/e2e
@@ -22,5 +22,3 @@ RUN npx playwright install --with-deps
 # Change the working directory back to the root to run the Makefile
 WORKDIR /app
 
-# Define the default command to run the tests
-# CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y make
 WORKDIR /app
 
 # Copy the entire project, including Makefile, into the Docker image
-COPY ../ .
+COPY . .
 
 # Change directory to e2e for subsequent commands
 WORKDIR /app/e2e

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -16,5 +16,8 @@ WORKDIR /app/e2e
 # Install the dependencies
 RUN npm ci
 
+# Change the working directory back to the root to run the Makefile
+WORKDIR /app
+
 # Define the default command to run the tests (you can override this in your CI or local runs)
 CMD ["make", "e2e-test"]

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -19,4 +19,4 @@ COPY e2e /e2e
 WORKDIR /
 
 # Default command when running the container
-CMD ["make", "e2e-test"]
+CMD ["make", "e2e-test-native"]

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5,10 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "e2e",
       "version": "1.0.0",
       "dependencies": {
         "@axe-core/playwright": "^4.9.1",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "playwright": "^1.48.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.45.1",
@@ -39,6 +41,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.45.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@types/node": {
@@ -73,7 +93,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -84,12 +103,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
-      "dev": true,
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
+      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
       "dependencies": {
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.48.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -105,6 +123,17 @@
       "version": "1.45.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
       "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
+      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -135,6 +164,18 @@
       "dev": true,
       "requires": {
         "playwright": "1.45.1"
+      },
+      "dependencies": {
+        "playwright": {
+          "version": "1.45.1",
+          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+          "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2",
+            "playwright-core": "1.45.1"
+          }
+        }
       }
     },
     "@types/node": {
@@ -160,17 +201,22 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-      "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
-      "dev": true,
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
+      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.48.1"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.48.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
+          "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA=="
+        }
       }
     },
     "playwright-core": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,7 +2,7 @@
   "name": "e2e",
   "version": "1.0.0",
   "scripts": {
-    "e2e-setup": "npx playwright install",
+    "e2e-setup": "npx playwright install --with-deps",
     "e2e-test": "./run-e2e-test",
     "e2e-test:ui": "npx playwright test --ui"
   },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@axe-core/playwright": "^4.9.1",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "playwright": "^1.48.1"
   }
 }


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-infra/issues/735

## Changes

- containerize e2e tests with playwright image


## Context
- Imrproves portability and avoids having to `apt-get` a bunch of packages https://github.com/navapbc/template-infra/blob/32ce571bd5656c4efc0615c58b2e8ed2a3a739f8/Makefile#L235
- For all local e2e testing - you'll need to have the app running locally and call the run command with the correct port and app (folder name) (hitting your locally running app from local docker uses a base url of `host.docker.internal`)

- PR checks are still testing against the PR preview env 


Opened on a `template-infra` => https://github.com/navapbc/template-infra/pull/770


https://playwright.dev/docs/docker

https://github.com/user-attachments/assets/be6ff595-6a81-49e4-823a-32a978a236b5


<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-88-app-dev-2033577064.us-east-1.elb.amazonaws.com
- Deployed commit: afdde0ddee55dc7bc75016aa5514e81ca6237b82
<!-- end PR environment info -->