### PR TITLE
Update playwright config to never open html report

### DIFF
--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -23,7 +23,8 @@ export default defineConfig({
   // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
   reporter: process.env.CI
   ? [['blob']]  :
-    // Never open the HTML report to prevent terminal from hanging on test failure
+    // Don't open the HTML report since it hangs when running inside a container.
+    // Use make e2e-show-report for opening the HTML report
     [['html', { open: 'never' }]],
   // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
   use: {

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -24,8 +24,7 @@ export default defineConfig({
   reporter: process.env.CI
   ? [['blob']]  :
     // Never open the HTML report to prevent terminal from hanging on test failure
-    [['html', { open: 'never' }],
-  ],
+    [['html', { open: 'never' }]],
   // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
   use: {
     // Base URL to use in actions like `await page.goto('/')`.

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -21,7 +21,11 @@ export default defineConfig({
   // Opt out of parallel tests on CI.
   workers: process.env.CI ? 1 : undefined,
   // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
-  reporter: process.env.CI ? 'blob' : 'html',
+  reporter: process.env.CI
+  ? [['blob']]  :
+    // Never open the HTML report to prevent terminal from hanging on test failure
+    [['html', { open: 'never' }],
+  ],
   // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
   use: {
     // Base URL to use in actions like `await page.goto('/')`.


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/788

## Changes

 - update base config `./e2e/playwright.config` to never open html report

## Context for reviewers

- this works for both `make e2e-test` and `make e2e-test-native` when calling against an `BASE_URL` that doesn't exist


## Testing


https://github.com/user-attachments/assets/8619d107-0b06-4a2c-8554-4c45226f1c76




<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-92-app-dev-1734024718.us-east-1.elb.amazonaws.com
- Deployed commit: 45022fa9a9e7da9a7c8bec8bb145e0f308d01f20
<!-- app - end PR environment info -->