### PR TITLE
Resolve Storybook build error

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,4 +1,6 @@
 // @ts-check
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
 const withNextIntl = require("next-intl/plugin")("./src/i18n/server.ts");
 const sassOptions = require("./scripts/sassOptions");
 
@@ -27,4 +29,4 @@ const nextConfig = {
   ],
 };
 
-module.exports = withNextIntl(nextConfig);
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Ticket

Resolves [Deploy Storybook Actions step](https://github.com/navapbc/platform-test-nextjs/actions/runs/13999633004/job/39202912601)

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated `.storybook/main.js` and `next.config.js` based on ECMAScript Modules instead of CommonJS
  - **`.storybook/main.js`:**
    ```
    import path, { dirname } from "path";
    import { fileURLToPath } from "URL";

    const __filename = fileURLToPath(import.meta.url);
    const __dirname = dirname(__filename);
    ```
  - **`next.config.js`:**
    ```
    import { createRequire } from "node:module";
    const require = createRequire(import.meta.url);
    ...
    export default withNextIntl(nextConfig);
    ```

## Context for reviewers

<!-- Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. -->
Storybook was having issues with building and running in the `template-application-nextjs` repo. The particular error was about `.storybook/main.js` having problems with resolving the `__dirname` path in the nextConfigPath variable. This issue comes from some changes in how Storybook and Node.js handle JavaScript files/modules. Storybook is having issues with using CommonJS, so the apparent solution at the time was to update the `.storybook/main.js` config file to support Node.js ESM. More can be found here: [template-application-next.js: issue #387](https://github.com/navapbc/template-application-nextjs/issues/387).

After pushing this change to main in that repo, it has caused some issues in the deployment pipeline of this one. The CI/CD pipeline failed at the [Deploy Storybook step](https://github.com/navapbc/platform-test-nextjs/actions/runs/13999633004/job/39202912601). Based on the error, the exact cause is a bit unclear because it gives the error `ReferenceError: require is not defined` which is a little confusing because `.storybook/main.js` does not use this node module. It appears that this issue may be bubbling up from the `next.config.js` file as this is the only file referenced in `.storybook/main.js` and it does use the `require` module. The `next.config.js` will need to be updated to support ESM instead of CommonJS Node modules. 

## Testing

<!-- Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://getkap.co/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox. -->
